### PR TITLE
Fix: Cast to float before applying torch.finfo

### DIFF
--- a/src/transformers/models/glm4v/modeling_glm4v.py
+++ b/src/transformers/models/glm4v/modeling_glm4v.py
@@ -1301,14 +1301,11 @@ class Glm4vModel(Glm4vPreTrainedModel):
             )
             if attention_mask_tensor is not None and attention_mask_tensor.ndim == 4:
                 attention_mask_tensor = torch.diagonal(attention_mask_tensor[:, 0], dim1=1, dim2=2)
-                # Fix: Cast to float before applying torch.finfo
+                # Only apply conversion for floating point tensors (inverted masks)
                 if attention_mask_tensor.dtype.is_floating_point:
-                    min_val = torch.finfo(attention_mask_tensor.dtype).min
-                else:
-                    min_val = torch.iinfo(attention_mask_tensor.dtype).min
-                attention_mask_tensor = attention_mask_tensor / min_val
-                attention_mask_tensor = (1.0 - attention_mask_tensor).int()
-
+                    attention_mask_tensor = attention_mask_tensor / torch.finfo(attention_mask_tensor.dtype).min
+                    attention_mask_tensor = (1.0 - attention_mask_tensor).int()
+        
             # Calculate RoPE index once per generation in the pre-fill stage only.
             # When compiling, we can't check tensor values thus we check only input length
             # It is safe to assume that `length!=1` means we're in pre-fill because compiled

--- a/src/transformers/models/glm4v/modeling_glm4v.py
+++ b/src/transformers/models/glm4v/modeling_glm4v.py
@@ -1301,7 +1301,12 @@ class Glm4vModel(Glm4vPreTrainedModel):
             )
             if attention_mask_tensor is not None and attention_mask_tensor.ndim == 4:
                 attention_mask_tensor = torch.diagonal(attention_mask_tensor[:, 0], dim1=1, dim2=2)
-                attention_mask_tensor = attention_mask_tensor / torch.finfo(attention_mask_tensor.dtype).min
+                # Fix: Cast to float before applying torch.finfo
+                if attention_mask_tensor.dtype.is_floating_point:
+                    min_val = torch.finfo(attention_mask_tensor.dtype).min
+                else:
+                    min_val = torch.iinfo(attention_mask_tensor.dtype).min
+                attention_mask_tensor = attention_mask_tensor / min_val
                 attention_mask_tensor = (1.0 - attention_mask_tensor).int()
 
             # Calculate RoPE index once per generation in the pre-fill stage only.

--- a/src/transformers/models/glm4v/modular_glm4v.py
+++ b/src/transformers/models/glm4v/modular_glm4v.py
@@ -1297,13 +1297,10 @@ class Glm4vModel(Qwen2_5_VLModel):
             )
             if attention_mask_tensor is not None and attention_mask_tensor.ndim == 4:
                 attention_mask_tensor = torch.diagonal(attention_mask_tensor[:, 0], dim1=1, dim2=2)
-                # Fix: Cast to float before applying torch.finfo
+                # Only apply conversion for floating point tensors (inverted masks)
                 if attention_mask_tensor.dtype.is_floating_point:
-                    min_val = torch.finfo(attention_mask_tensor.dtype).min
-                else:
-                    min_val = torch.iinfo(attention_mask_tensor.dtype).min
-                attention_mask_tensor = attention_mask_tensor / min_val
-                attention_mask_tensor = (1.0 - attention_mask_tensor).int()
+                    attention_mask_tensor = attention_mask_tensor / torch.finfo(attention_mask_tensor.dtype).min
+                    attention_mask_tensor = (1.0 - attention_mask_tensor).int()
 
             # Calculate RoPE index once per generation in the pre-fill stage only.
             # When compiling, we can't check tensor values thus we check only input length

--- a/src/transformers/models/glm4v/modular_glm4v.py
+++ b/src/transformers/models/glm4v/modular_glm4v.py
@@ -1297,7 +1297,12 @@ class Glm4vModel(Qwen2_5_VLModel):
             )
             if attention_mask_tensor is not None and attention_mask_tensor.ndim == 4:
                 attention_mask_tensor = torch.diagonal(attention_mask_tensor[:, 0], dim1=1, dim2=2)
-                attention_mask_tensor = attention_mask_tensor / torch.finfo(attention_mask_tensor.dtype).min
+                # Fix: Cast to float before applying torch.finfo
+                if attention_mask_tensor.dtype.is_floating_point:
+                    min_val = torch.finfo(attention_mask_tensor.dtype).min
+                else:
+                    min_val = torch.iinfo(attention_mask_tensor.dtype).min
+                attention_mask_tensor = attention_mask_tensor / min_val
                 attention_mask_tensor = (1.0 - attention_mask_tensor).int()
 
             # Calculate RoPE index once per generation in the pre-fill stage only.

--- a/src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
+++ b/src/transformers/models/qwen2_5_vl/modeling_qwen2_5_vl.py
@@ -1289,13 +1289,10 @@ class Qwen2_5_VLModel(Qwen2_5_VLPreTrainedModel):
             )
             if attention_mask_tensor is not None and attention_mask_tensor.ndim == 4:
                 attention_mask_tensor = torch.diagonal(attention_mask_tensor[:, 0], dim1=1, dim2=2)
-                # Fix: Cast to float before applying torch.finfo
+                # Only apply conversion for floating point tensors (inverted masks)
                 if attention_mask_tensor.dtype.is_floating_point:
-                    min_val = torch.finfo(attention_mask_tensor.dtype).min
-                else:
-                    min_val = torch.iinfo(attention_mask_tensor.dtype).min                    
-                attention_mask_tensor = attention_mask_tensor / min_val
-                attention_mask_tensor = (1.0 - attention_mask_tensor).int()
+                    attention_mask_tensor = attention_mask_tensor / torch.finfo(attention_mask_tensor.dtype).min
+                    attention_mask_tensor = (1.0 - attention_mask_tensor).int()
 
             # Calculate RoPE index once per generation in the pre-fill stage only.
             # When compiling, we can't check tensor values thus we check only input length

--- a/src/transformers/models/qwen2_5_vl/modular_qwen2_5_vl.py
+++ b/src/transformers/models/qwen2_5_vl/modular_qwen2_5_vl.py
@@ -639,13 +639,10 @@ class Qwen2_5_VLModel(Qwen2VLModel):
             )
             if attention_mask_tensor is not None and attention_mask_tensor.ndim == 4:
                 attention_mask_tensor = torch.diagonal(attention_mask_tensor[:, 0], dim1=1, dim2=2)
-                # Fix: Cast to float before applying torch.finfo
+                # Only apply conversion for floating point tensors (inverted masks)
                 if attention_mask_tensor.dtype.is_floating_point:
-                    min_val = torch.finfo(attention_mask_tensor.dtype).min
-                else:
-                    min_val = torch.iinfo(attention_mask_tensor.dtype).min
-                attention_mask_tensor = attention_mask_tensor / min_val
-                attention_mask_tensor = (1.0 - attention_mask_tensor).int()
+                    attention_mask_tensor = attention_mask_tensor / torch.finfo(attention_mask_tensor.dtype).min
+                    attention_mask_tensor = (1.0 - attention_mask_tensor).int()
 
             # Calculate RoPE index once per generation in the pre-fill stage only.
             # When compiling, we can't check tensor values thus we check only input length

--- a/src/transformers/models/qwen2_5_vl/modular_qwen2_5_vl.py
+++ b/src/transformers/models/qwen2_5_vl/modular_qwen2_5_vl.py
@@ -639,7 +639,12 @@ class Qwen2_5_VLModel(Qwen2VLModel):
             )
             if attention_mask_tensor is not None and attention_mask_tensor.ndim == 4:
                 attention_mask_tensor = torch.diagonal(attention_mask_tensor[:, 0], dim1=1, dim2=2)
-                attention_mask_tensor = attention_mask_tensor / torch.finfo(attention_mask_tensor.dtype).min
+                # Fix: Cast to float before applying torch.finfo
+                if attention_mask_tensor.dtype.is_floating_point:
+                    min_val = torch.finfo(attention_mask_tensor.dtype).min
+                else:
+                    min_val = torch.iinfo(attention_mask_tensor.dtype).min
+                attention_mask_tensor = attention_mask_tensor / min_val
                 attention_mask_tensor = (1.0 - attention_mask_tensor).int()
 
             # Calculate RoPE index once per generation in the pre-fill stage only.


### PR DESCRIPTION
The CI is failing because the same torch.finfo() bug exists in multiple related models that share similar code. The fix needs to be applied consistently across:

qwen2_5_vl ✅ (already fixed)
qwen2_5_omni ❌ (needs same fix)
glm4v ❌ (needs same fix)

Action needed: Apply the same dtype checking fix to all affected models to ensure code consistency across the codebase.
Files to update:

src/transformers/models/qwen2_5_omni/modeling_qwen2_5_omni.py
src/transformers/models/glm4v/modeling_glm4v.py

This is a standard requirement in the Transformers codebase to maintain consistency when multiple models share similar patterns.